### PR TITLE
c2/cuda/*: drop slice_t and refactor

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [patch.crates-io]
-sppark = { git = "https://github.com/supranational/sppark" }
+sppark = { git = "https://github.com/dot-asm/sppark", branch="slice_t" }
 bellperson = { path = "c2/bellperson", version = "0.25.0"}

--- a/c2/cuda/groth16_ntt_h.cu
+++ b/c2/cuda/groth16_ntt_h.cu
@@ -74,10 +74,11 @@ public:
     // a is the result vector
     static void execute_ntt_msm_h(const gpu_t& gpu, gpu_ptr_t<fr_t> d_a,
                                   const Assignment<fr_t>& input,
-                                  const affine_t points_h[], size_t npoints,
+                                  slice_t<affine_t> points_h,
                                   point_t& result_h)
     {
         size_t actual_size = input.abc_size;
+        size_t npoints = points_h.size();
         size_t lg_domain_size = lg2(npoints - 1) + 1;
         size_t domain_size = (size_t)1 << lg_domain_size;
 
@@ -119,7 +120,7 @@ public:
         gpu[1 + lot_of_memory].sync();
 
         msm_t<bucket_t, point_t, affine_t, fr_t> msm(nullptr, npoints);
-        msm.invoke(result_h, points_h, npoints, d_a, true);
+        msm.invoke(result_h, points_h, d_a, true);
     }
 };
 

--- a/c2/cuda/groth16_split_msm.cu
+++ b/c2/cuda/groth16_split_msm.cu
@@ -77,7 +77,7 @@ template<class bucket_t,
          class affine_h = class bucket_t::affine_t::mem_t>
 void execute_batch_addition(const gpu_t& gpu,
                             size_t circuit0, size_t num_circuits,
-                            const affine_t points[], size_t npoints,
+                            slice_t<affine_t> points,
                             const split_vectors& split_vector,
                             point_t batch_add_res[])
 {
@@ -104,10 +104,9 @@ void execute_batch_addition(const gpu_t& gpu,
     uint32_t sid = 0;
 
     for (size_t c = 0; c < num_circuits; c++)
-        gpu[sid].HtoD(d_bit_vectors[c],
-                      split_vector.bit_vector[circuit0 + c].data(),
-                      split_vector.bit_vector[circuit0 + c].size());
+        gpu[sid].HtoD(d_bit_vectors[c], split_vector.bit_vector[circuit0 + c]);
 
+    size_t npoints = points.size();
     for (uint32_t batch = 0; npoints > 0; batch++, sid ^= 1) {
         uint32_t amount = std::min(npoints, batch_size);
         size_t cursor = batch * batch_size;


### PR DESCRIPTION
This has to be synchronized with https://github.com/supranational/sppark/pull/17, and the commit that modifies .cargo/config.toml will have to be omitted.
