### PR TITLE
demos/.cargo/config.toml: exercise dot-asm/bellperson:supraseal-facelift.

### DIFF
--- a/demos/.cargo/config.toml
+++ b/demos/.cargo/config.toml
@@ -1,2 +1,3 @@
 [patch.crates-io]
+bellperson = { git = "https://github.com/dot-asm/bellperson", branch="supraseal-facelift", version = "0.26.0"}
 supraseal-c2 = { path = "../c2" }


### PR DESCRIPTION
@vmx, I should have checked and suggested this earlier, sorry about that, but have a look at https://github.com/dot-asm/bellperson/commit/c033439668a2f02581a3ca521401b5020872d042. The "keyword" there is switch from `supraseal_c2::generate_groth16_proof()` to `supraseal_c2::generate_groth16_proofs()`. I can open pull request in the
[bellperson](https://github.com/filecoin-project/bellperson)...